### PR TITLE
Added a _.date prop to FormatDate and RelativeTime

### DIFF
--- a/project/ShoelaceGenerator.scala
+++ b/project/ShoelaceGenerator.scala
@@ -71,6 +71,7 @@ class ShoelaceGenerator(
       case "String" => "stringProp"
       case "Int" => "intProp"
       case "Double" => "doubleProp"
+      case "js.Date" => "dateProp"
       case "dom.MutationObserver" | "js.Array[js.Object]" => "asIsProp"
       case _ =>
         println(s"PROP ...No impl defined for scala type `${scalaTypeStr}`, trying `htmlProp` for now.")

--- a/project/ShoelaceGenerator.scala
+++ b/project/ShoelaceGenerator.scala
@@ -71,7 +71,7 @@ class ShoelaceGenerator(
       case "String" => "stringProp"
       case "Int" => "intProp"
       case "Double" => "doubleProp"
-      case "js.Date" => "dateProp"
+      case "js.Date | String" => "dateProp"
       case "dom.MutationObserver" | "js.Array[js.Object]" => "asIsProp"
       case _ =>
         println(s"PROP ...No impl defined for scala type `${scalaTypeStr}`, trying `htmlProp` for now.")

--- a/project/ShoelaceTranslator.scala
+++ b/project/ShoelaceTranslator.scala
@@ -135,7 +135,7 @@ class ShoelaceTranslator(
     (tagName, propName, jsTypes) match {
       // #nc #nc #nc vvvvvv TODO
       case ("sl-color-picker", "swatches", _) => true // Composite List[String] separated by ; IF used as an attribute. Property is an array, but not reflected.
-      case ("sl-format-date" | "sl-relative-time", "date", _) => true // Date | String - convert date with `date.toISOString()` - For MVP, just make an attribute, and a codec for date?
+      //case ("sl-format-date" | "sl-relative-time", "date", _) => true // Date | String - convert date with `date.toISOString()` - For MVP, just make an attribute, and a codec for date?
       // case ("sl-select", "value" | "defaultValue", _) => true // String | String[]. Space-delimited string in html attr. Use `value` vs `values`?
       // #nc #nc #nc ^^^^^ TODO
       // Don't want those props, we have (non-reflected) attributes for them.
@@ -594,7 +594,10 @@ class ShoelaceTranslator(
       //  println(s"WARNING: scalaAttrInputType: Multi-element input not supported for attr `${attr.attrName}` in tag `${tagName}`.")
       //  "Element" // #nc or Element[], but how to express that...
     } else {
-      throw new Exception(s"ERROR: scalaPropInputTypeStr does not support multiple printable types in prop `${prop.propName}` in tag `${tagName}`: ${printableTypes.mkString(", ")}")
+      printableTypes match {
+        case List(Def.JsCustomType("Date"), Def.JsStringType) => "js.Date"
+        case _ => throw new Exception(s"ERROR: scalaPropInputTypeStr does not support multiple printable types in prop `${prop.propName}` in tag `${tagName}`: ${printableTypes.mkString(", ")}")
+      }
     }
   }
 
@@ -634,6 +637,7 @@ class ShoelaceTranslator(
       case Def.JsCustomType("MutationObserver") => "dom.MutationObserver"
       case Def.JsCustomType("MutationRecord[]") => "js.Array[dom.MutationRecord]"
       case Def.JsCustomType("ResizeObserverEntry[]") => "js.Array[dom.ResizeObserverEntry]"
+      case Def.JsCustomType("Date") => "js.Date"
       case Def.JsCustomType(t) if t.startsWith("Sl") =>
         if (t.endsWith("[]")) {
           "js.Array[" + t.substring(2, t.length - 2) + ".Ref]"

--- a/project/ShoelaceTranslator.scala
+++ b/project/ShoelaceTranslator.scala
@@ -593,8 +593,8 @@ class ShoelaceTranslator(
       //  println(s"WARNING: scalaAttrInputType: Multi-element input not supported for attr `${attr.attrName}` in tag `${tagName}`.")
       //  "Element" // #nc or Element[], but how to express that...
     } else {
-      printableTypes match {
-        case List(Def.JsCustomType("Date"), Def.JsStringType) => "js.Date"
+      printableTypes.toSet match {
+        case s if s == Set(Def.JsCustomType("Date"), Def.JsStringType) => "js.Date" // I'm mapping from a JS Dom type to the Scala type. Here, I only want to work with `js.Date`s in Scala, not a union of `js.Date | String`
         case _ => throw new Exception(s"ERROR: scalaPropInputTypeStr does not support multiple printable types in prop `${prop.propName}` in tag `${tagName}`: ${printableTypes.mkString(", ")}")
       }
     }

--- a/project/ShoelaceTranslator.scala
+++ b/project/ShoelaceTranslator.scala
@@ -595,7 +595,7 @@ class ShoelaceTranslator(
     } else {
       if (printableTypes.toSet == Set(Def.JsCustomType("Date"), Def.JsStringType)) {
         // I'm mapping from a JS Dom type to the Scala type. Here, I only want to work with `js.Date`s in Scala, not a union of `js.Date | String`
-        "js.Date"
+        "js.Date | String"
       } else {
         throw new Exception(s"ERROR: scalaPropInputTypeStr does not support multiple printable types in prop `${prop.propName}` in tag `${tagName}`: ${printableTypes.mkString(", ")}")
       }

--- a/project/ShoelaceTranslator.scala
+++ b/project/ShoelaceTranslator.scala
@@ -135,7 +135,6 @@ class ShoelaceTranslator(
     (tagName, propName, jsTypes) match {
       // #nc #nc #nc vvvvvv TODO
       case ("sl-color-picker", "swatches", _) => true // Composite List[String] separated by ; IF used as an attribute. Property is an array, but not reflected.
-      //case ("sl-format-date" | "sl-relative-time", "date", _) => true // Date | String - convert date with `date.toISOString()` - For MVP, just make an attribute, and a codec for date?
       // case ("sl-select", "value" | "defaultValue", _) => true // String | String[]. Space-delimited string in html attr. Use `value` vs `values`?
       // #nc #nc #nc ^^^^^ TODO
       // Don't want those props, we have (non-reflected) attributes for them.

--- a/project/ShoelaceTranslator.scala
+++ b/project/ShoelaceTranslator.scala
@@ -593,9 +593,11 @@ class ShoelaceTranslator(
       //  println(s"WARNING: scalaAttrInputType: Multi-element input not supported for attr `${attr.attrName}` in tag `${tagName}`.")
       //  "Element" // #nc or Element[], but how to express that...
     } else {
-      printableTypes.toSet match {
-        case s if s == Set(Def.JsCustomType("Date"), Def.JsStringType) => "js.Date" // I'm mapping from a JS Dom type to the Scala type. Here, I only want to work with `js.Date`s in Scala, not a union of `js.Date | String`
-        case _ => throw new Exception(s"ERROR: scalaPropInputTypeStr does not support multiple printable types in prop `${prop.propName}` in tag `${tagName}`: ${printableTypes.mkString(", ")}")
+      if (printableTypes.toSet == Set(Def.JsCustomType("Date"), Def.JsStringType)) {
+        // I'm mapping from a JS Dom type to the Scala type. Here, I only want to work with `js.Date`s in Scala, not a union of `js.Date | String`
+        "js.Date"
+      } else {
+        throw new Exception(s"ERROR: scalaPropInputTypeStr does not support multiple printable types in prop `${prop.propName}` in tag `${tagName}`: ${printableTypes.mkString(", ")}")
       }
     }
   }

--- a/src/main/scala/com/raquo/laminar/shoelace/sl/CommonTypes.scala
+++ b/src/main/scala/com/raquo/laminar/shoelace/sl/CommonTypes.scala
@@ -9,6 +9,7 @@ import com.raquo.laminar.keys.DerivedStyleProp
 import com.raquo.laminar.modifiers.KeySetter
 import com.raquo.laminar.modifiers.KeySetter.StyleSetter
 import org.scalajs.dom
+import scala.scalajs.{js as sjs}
 
 trait CommonTypes {
 
@@ -32,7 +33,7 @@ trait CommonTypes {
   //private val stringAttrs = js.Dictionary[HtmlAttr[String]]()
 
   protected def eventProp[Ev <: dom.Event](name: String): EventProp[Ev] = L.eventProp(name)
-  
+
   protected def stringProp(name: String): HtmlProp[String, _] = L.htmlProp(name, StringAsIsCodec)
 
   protected def intProp(name: String): HtmlProp[Int, _] = L.htmlProp(name, IntAsIsCodec)
@@ -42,6 +43,8 @@ trait CommonTypes {
   protected def boolProp(name: String): HtmlProp[Boolean, _] = L.htmlProp(name, BooleanAsIsCodec)
 
   protected def asIsProp[V](name: String): HtmlProp[V, _] = L.htmlProp(name, AsIsCodec[V]())
+
+  protected def dateProp(name: String): HtmlProp[sjs.Date, _] = L.htmlProp(name, DateAsStringCodec)
 
   protected def boolAttr(name: String): HtmlAttr[Boolean] = {
     L.htmlAttr(name, BooleanAsAttrPresenceCodec)

--- a/src/main/scala/com/raquo/laminar/shoelace/sl/CommonTypes.scala
+++ b/src/main/scala/com/raquo/laminar/shoelace/sl/CommonTypes.scala
@@ -44,7 +44,7 @@ trait CommonTypes {
 
   protected def asIsProp[V](name: String): HtmlProp[V, _] = L.htmlProp(name, AsIsCodec[V]())
 
-  protected def dateProp(name: String): HtmlProp[js.Date, _] = L.htmlProp(name, DateAsStringCodec)
+  protected def dateProp(name: String): HtmlProp[js.Date | String, _] = L.htmlProp(name, AsIsCodec[js.Date | String]())
 
   protected def boolAttr(name: String): HtmlAttr[Boolean] = {
     L.htmlAttr(name, BooleanAsAttrPresenceCodec)

--- a/src/main/scala/com/raquo/laminar/shoelace/sl/CommonTypes.scala
+++ b/src/main/scala/com/raquo/laminar/shoelace/sl/CommonTypes.scala
@@ -9,7 +9,7 @@ import com.raquo.laminar.keys.DerivedStyleProp
 import com.raquo.laminar.modifiers.KeySetter
 import com.raquo.laminar.modifiers.KeySetter.StyleSetter
 import org.scalajs.dom
-import scala.scalajs.{js as sjs}
+import scala.scalajs.js
 
 trait CommonTypes {
 
@@ -44,7 +44,7 @@ trait CommonTypes {
 
   protected def asIsProp[V](name: String): HtmlProp[V, _] = L.htmlProp(name, AsIsCodec[V]())
 
-  protected def dateProp(name: String): HtmlProp[sjs.Date, _] = L.htmlProp(name, DateAsStringCodec)
+  protected def dateProp(name: String): HtmlProp[js.Date, _] = L.htmlProp(name, DateAsStringCodec)
 
   protected def boolAttr(name: String): HtmlAttr[Boolean] = {
     L.htmlAttr(name, BooleanAsAttrPresenceCodec)

--- a/src/main/scala/com/raquo/laminar/shoelace/sl/FormatDate.scala
+++ b/src/main/scala/com/raquo/laminar/shoelace/sl/FormatDate.scala
@@ -73,7 +73,7 @@ object FormatDate extends WebComponent("sl-format-date") {
     * recommended to use the ISO 8601 format to ensure timezones are handled correctly. To convert a date to this format
     * in JavaScript, use [`date.toISOString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).
     */
-  lazy val date: HtmlProp[js.Date, _] = dateProp("date")
+  lazy val date: HtmlProp[js.Date | String, _] = dateProp("date")
 
 
   // -- Slots --

--- a/src/main/scala/com/raquo/laminar/shoelace/sl/FormatDate.scala
+++ b/src/main/scala/com/raquo/laminar/shoelace/sl/FormatDate.scala
@@ -1,6 +1,6 @@
 package com.raquo.laminar.shoelace.sl
 
-import com.raquo.laminar.keys.{HtmlAttr}
+import com.raquo.laminar.keys.{HtmlProp, HtmlAttr}
 import com.raquo.laminar.api.L
 import org.scalajs.dom
 
@@ -68,6 +68,13 @@ object FormatDate extends WebComponent("sl-format-date") {
 
   // -- Props --
 
+  /**
+    * The date/time to format. If not set, the current date and time will be used. When passing a string, it's strongly
+    * recommended to use the ISO 8601 format to ensure timezones are handled correctly. To convert a date to this format
+    * in JavaScript, use [`date.toISOString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).
+    */
+  lazy val date: HtmlProp[js.Date, _] = dateProp("date")
+
 
   // -- Slots --
 
@@ -87,6 +94,13 @@ object FormatDate extends WebComponent("sl-format-date") {
   // -- Element type -- 
 
   @js.native trait FormatDateComponent extends js.Object { this: dom.HTMLElement => 
+
+    /**
+      * The date/time to format. If not set, the current date and time will be used. When passing a string, it's strongly
+      * recommended to use the ISO 8601 format to ensure timezones are handled correctly. To convert a date to this format
+      * in JavaScript, use [`date.toISOString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).
+      */
+    var date: js.Date | String
 
     /** The format for displaying the weekday. */
     var weekday: String

--- a/src/main/scala/com/raquo/laminar/shoelace/sl/RelativeTime.scala
+++ b/src/main/scala/com/raquo/laminar/shoelace/sl/RelativeTime.scala
@@ -52,7 +52,7 @@ object RelativeTime extends WebComponent("sl-relative-time") {
     * string, it's strongly recommended to use the ISO 8601 format to ensure timezones are handled correctly. To convert
     * a date to this format in JavaScript, use [`date.toISOString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).
     */
-  lazy val date: HtmlProp[js.Date, _] = dateProp("date")
+  lazy val date: HtmlProp[js.Date | String, _] = dateProp("date")
 
 
   // -- Slots --

--- a/src/main/scala/com/raquo/laminar/shoelace/sl/RelativeTime.scala
+++ b/src/main/scala/com/raquo/laminar/shoelace/sl/RelativeTime.scala
@@ -1,6 +1,6 @@
 package com.raquo.laminar.shoelace.sl
 
-import com.raquo.laminar.keys.{HtmlAttr}
+import com.raquo.laminar.keys.{HtmlProp, HtmlAttr}
 import com.raquo.laminar.api.L
 import org.scalajs.dom
 
@@ -47,6 +47,13 @@ object RelativeTime extends WebComponent("sl-relative-time") {
 
   // -- Props --
 
+  /**
+    * The date from which to calculate time from. If not set, the current date and time will be used. When passing a
+    * string, it's strongly recommended to use the ISO 8601 format to ensure timezones are handled correctly. To convert
+    * a date to this format in JavaScript, use [`date.toISOString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).
+    */
+  lazy val date: HtmlProp[js.Date, _] = dateProp("date")
+
 
   // -- Slots --
 
@@ -66,6 +73,13 @@ object RelativeTime extends WebComponent("sl-relative-time") {
   // -- Element type -- 
 
   @js.native trait RelativeTimeComponent extends js.Object { this: dom.HTMLElement => 
+
+    /**
+      * The date from which to calculate time from. If not set, the current date and time will be used. When passing a
+      * string, it's strongly recommended to use the ISO 8601 format to ensure timezones are handled correctly. To convert
+      * a date to this format in JavaScript, use [`date.toISOString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).
+      */
+    var date: js.Date | String
 
     /** The formatting style to use. */
     var format: String


### PR DESCRIPTION
Adds support for passing a JavaScript Date to the Shoelace FormatDate and RelativeTime components. Before, these components rendered times relative to when they were instantiated. Now, any date can be given.  
This pull request also touches a couple of other projects.  
## [Laminar](https://github.com/raquo/Laminar)
A new codec is needed to support passing dates to Shoelace:
```patch
diff --git a/src/main/scala/com/raquo/laminar/codecs/package.scala b/src/main/scala/com/raquo/laminar/codecs/package.scala
index 1d75644..b98752b 100644
--- a/src/main/scala/com/raquo/laminar/codecs/package.scala
+++ b/src/main/scala/com/raquo/laminar/codecs/package.scala
@@ -1,4 +1,5 @@
 package com.raquo.laminar
+import scala.scalajs.{js as sjs}
 
 package object codecs {
 
@@ -69,6 +70,15 @@ package object codecs {
     override def encode(scalaValue: Boolean): String = if (scalaValue) "on" else "off"
   }
 
+  // Date Codecs
+
+  lazy val DateAsStringCodec = new Codec[sjs.Date, String] {
+
+    override def decode(domValue: String): sjs.Date = new sjs.Date(domValue)
+
+    override def encode(scalaValue: sjs.Date): String = scalaValue.toISOString()
+  }
+
   // Iterable Codecs
 
   @deprecated("Laminar no longer uses IterableAsSpaceSeparatedStringCodec so I plan to remove it; if you need it, please let me know", "15.0.0-M7")
```
## (Optional demo) [Laminar Full Stack Demo](https://github.com/raquo/laminar-full-stack-demo)
Here's a patch where I add three examples to the [Shoelace component demo page](http://localhost:3000/app/integrations/web-components/shoelace). I would recommend against having these components live as an example on this page for anything more than quick testing, especially given that the [Shoelace docs already describe a `date` property](https://shoelace.style/components/relative-time/#properties).
```patch
diff --git a/client/src/main/scala/com/raquo/app/integrations/ShoelaceWebComponentsView.scala b/client/src/main/scala/com/raquo/app/integrations/ShoelaceWebComponentsView.scala
index 3df4c82..ca82ec2 100644
--- a/client/src/main/scala/com/raquo/app/integrations/ShoelaceWebComponentsView.scala
+++ b/client/src/main/scala/com/raquo/app/integrations/ShoelaceWebComponentsView.scala
@@ -211,6 +211,16 @@ object ShoelaceWebComponentsView {
         CodeSnippets(_.`shoelace/css-custom-properties`)
       ),
       p("Above is a standard ", a(href("https://shoelace.style/components/switch"), "Switch"), " component, followed by a Switch that is custom-sized using custom CSS properties that this web component exposes."),
+      p("This should be, exactly, '3 days ago': ", sl.RelativeTime.of(
+        _.date(new js.Date(js.Date.now() - (24*60*60*1000 * 3)))
+      )),
+      p("This should update to show how long has passed since you loaded this page: ", sl.RelativeTime.of(
+        _.date(new js.Date()),
+        _.sync(true)
+      )),
+      p("This should be, exactly, '7/16/2024': ", sl.FormatDate.of(
+        _.date(new js.Date("2024-07-16T19:02:58.854Z"))
+      )),
     )
   }
 }
```
## Additional considerations and discussion items
In [ShoelaceTranslator.scala](project/ShoelaceTranslator.scala), I chose a dominant type (in this case, a js `Date`) from the union `Date | String` to pass through to Shoelace. However, the Shoelace docs describe the `date` prop as accepting a `Date | string`. Would support for union types like this be desirable in properties like `_.date(...)`?